### PR TITLE
#14 Fixing situation where supplying option without value were causing it to be cast to `bool`.

### DIFF
--- a/src/inausoft.netCLI.Tests/RegexArgumentDeserializerTests.cs
+++ b/src/inausoft.netCLI.Tests/RegexArgumentDeserializerTests.cs
@@ -93,6 +93,26 @@ namespace inausoft.netCLI.Tests
         }
 
         [TestMethod]
+        public void RegexOptionsDeserializer_Deserialize_ThrowsDeserializationException_WhenNoValueWasSpecifiedForNotBooleanProperty()
+        {
+            //Arrange
+            var args = new string[]
+                            {
+                                "--stringOption",
+                                "--boolOption", "true",
+                                "--intOption", "1"
+                            };
+
+            var deserializer = new RegexOptionsDeserializer();
+
+            //Act
+            var exception = Assert.ThrowsException<DeserializationException>(() => deserializer.Deserialize<Command1>(args));
+
+            //Assert
+            Assert.AreEqual(ErrorCode.OptionValueMissing, exception.ErrorCode);
+        }
+
+        [TestMethod]
         public void RegexArgumentHandler_ThrowsDeserializationException_WhenNotAllRequiredOptionsWereSupplied()
         {
             //Arrange

--- a/src/inausoft.netCLI/CLFlow.cs
+++ b/src/inausoft.netCLI/CLFlow.cs
@@ -79,7 +79,7 @@ namespace inausoft.netCLI
             {
                 return Fallback(ex.ErrorCode);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 return Fallback(ErrorCode.Unknown);
             }

--- a/src/inausoft.netCLI/Deserialization/RegexOptionsDeserializer.cs
+++ b/src/inausoft.netCLI/Deserialization/RegexOptionsDeserializer.cs
@@ -65,7 +65,14 @@ namespace inausoft.netCLI.Deserialization
                 //if there is no value for an option. Ex. 'move --force' as 'opposed to --force true'
                 if (string.IsNullOrEmpty(option.Groups[2].Value))
                 {
-                    property.SetMethod.Invoke(command, new object[] { true });
+                    if (property.PropertyType == typeof(bool))
+                    {
+                        property.SetMethod.Invoke(command, new object[] { true });
+                    }
+                    else
+                    {
+                        throw new DeserializationException(ErrorCode.OptionValueMissing, $"No value was specified for option : {optionName}.");
+                    }
                 }
                 else
                 {

--- a/src/inausoft.netCLI/ErrorCode.cs
+++ b/src/inausoft.netCLI/ErrorCode.cs
@@ -10,5 +10,6 @@
         UnrecognizedOption = 21,
         InvalidOptionsFormat = 22,
         RequiredOptionMissing = 23,
+        OptionValueMissing = 24,
     }
 }

--- a/src/netCLISample/Program.cs
+++ b/src/netCLISample/Program.cs
@@ -39,6 +39,9 @@ namespace netCLISample
         {
             switch (errorCode)
             {
+                case ErrorCode.OptionValueMissing:
+                    logger.LogError("Could not execute command. Value was not specified for one of the options.");
+                    break;
                 case ErrorCode.RequiredOptionMissing:
                     logger.LogError("Could not execute command. Some required options were missing.");
                     break;
@@ -60,7 +63,7 @@ namespace netCLISample
         public string PathFrom { get; set; }
 
         [Option("to", "Destination path for the files.")]
-        public bool PathTo { get; set; }
+        public string PathTo { get; set; }
     }
 
     public class MoveCommandHandler : CommandHandler<MoveCommand>


### PR DESCRIPTION
As discussed in #14. There is a proper ErrorCode now for described situation.